### PR TITLE
Add some initial limits to hopefully deal with connection starvation

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cyverse-de/configurate"
 	a "github.com/cyverse-de/data-usage-api/amqp"
@@ -90,7 +91,12 @@ func main() {
 	}
 
 	dbconn = sqlx.MustConnect("postgres", configuration.DBURI)
+	dbconn.SetMaxOpenConns(10)
+	dbconn.SetConnMaxIdleTime(time.Minute)
+
 	icatconn = sqlx.MustConnect("postgres", configuration.ICATURI)
+	icatconn.SetMaxOpenConns(10)
+	icatconn.SetConnMaxIdleTime(time.Minute)
 
 	// configure and start AMQP bits here
 	listenClient, err := messaging.NewClient(configuration.AMQPURI, true)


### PR DESCRIPTION
specifically: 10 max open connections on each database, 1 minute max idle time, and cancel contexts after a timeout

I'd also like to do another PR which will make it so the transactions are held open for shorter periods; in particular, so that the ICAT transaction is opened, used, and closed before the DE transaction is opened, used, and then closed. But that will take more intensive surgery on the code, so I figured I'd get this part up and maybe pushed out ASAP.