### PR TITLE
Refactors and transaction improvements

### DIFF
--- a/amqp/handlers.go
+++ b/amqp/handlers.go
@@ -31,7 +31,7 @@ func UpdateUserHandler(del amqp.Delivery, dedb, icat *sqlx.DB, configuration *co
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	dbs, rb, commit, err := db.NewBothTx(ctx, dedb, configuration.DBSchema, icat, configuration.UserSuffix, configuration.Zone, configuration.RootResourceNames)
+	dbs, rb, commit, err := db.NewBothTx(ctx, dedb, icat, configuration)
 	if err != nil {
 		e := errors.Wrap(err, "Failed setting up database")
 		log.Error(e)
@@ -75,7 +75,7 @@ func UpdateUserBatchHandler(del amqp.Delivery, dedb, icat *sqlx.DB, configuratio
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	dbs, rb, commit, err := db.NewBothTx(ctx, dedb, configuration.DBSchema, icat, configuration.UserSuffix, configuration.Zone, configuration.RootResourceNames)
+	dbs, rb, commit, err := db.NewBothTx(ctx, dedb, icat, configuration)
 	if err != nil {
 		e := errors.Wrap(err, "Failed setting up database")
 		log.Error(e)

--- a/amqp/handlers.go
+++ b/amqp/handlers.go
@@ -115,7 +115,7 @@ func SendBatchMessages(del amqp.Delivery, dedb, icat *sqlx.DB, amqpClient *messa
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	i := db.NewICAT(icat, configuration.UserSuffix, configuration.Zone, configuration.RootResourceNames)
+	i := db.NewICAT(icat, configuration)
 	batches, err := i.GetUserBatchBounds(ctx, configuration.BatchSize)
 	if err != nil {
 		return errors.Wrap(err, "Failed getting user batch bounds")

--- a/api/lookup.go
+++ b/api/lookup.go
@@ -23,7 +23,7 @@ func (a *App) UserCurrentUsageHandler(c echo.Context) error {
 	}
 	user = util.FixUsername(user, a.configuration)
 
-	dedb := db.NewDE(a.dedb, a.configuration.DBSchema)
+	dedb := db.NewDE(a.dedb, a.configuration)
 
 	res, err := dedb.UserCurrentDataUsage(context, user)
 

--- a/api/update.go
+++ b/api/update.go
@@ -19,7 +19,7 @@ func (a *App) UpdateUserCurrentUsageHandler(c echo.Context) error {
 	}
 	user = util.FixUsername(user, a.configuration)
 
-	dbs, rb, commit, err := db.NewBothTx(context, a.dedb, a.configuration.DBSchema, a.icat, a.configuration.UserSuffix, a.configuration.Zone, a.configuration.RootResourceNames)
+	dbs, rb, commit, err := db.NewBothTx(context, a.dedb, a.icat, a.configuration)
 	if err != nil {
 		e := errors.Wrap(err, "Failed setting up database")
 		log.Error(e)

--- a/api/update.go
+++ b/api/update.go
@@ -19,13 +19,7 @@ func (a *App) UpdateUserCurrentUsageHandler(c echo.Context) error {
 	}
 	user = util.FixUsername(user, a.configuration)
 
-	dbs, rb, commit, err := db.NewBothTx(context, a.dedb, a.icat, a.configuration)
-	if err != nil {
-		e := errors.Wrap(err, "Failed setting up database")
-		log.Error(e)
-		return logging.ErrorResponse{Message: e.Error(), ErrorCode: "500", HTTPStatusCode: http.StatusInternalServerError}
-	}
-	defer rb()
+	dbs := db.NewBoth(a.dedb, a.icat, a.configuration)
 
 	res, err := dbs.UpdateUserDataUsage(context, user)
 	if err != nil {
@@ -33,12 +27,6 @@ func (a *App) UpdateUserCurrentUsageHandler(c echo.Context) error {
 		log.Error(e)
 		return logging.ErrorResponse{Message: e.Error(), ErrorCode: "500", HTTPStatusCode: http.StatusInternalServerError}
 
-	}
-	err = commit()
-	if err != nil {
-		e := errors.Wrap(err, "Failed updating usage information")
-		log.Error(e)
-		return logging.ErrorResponse{Message: e.Error(), ErrorCode: "500", HTTPStatusCode: http.StatusInternalServerError}
 	}
 
 	return c.JSON(http.StatusOK, res)

--- a/db/coordination.go
+++ b/db/coordination.go
@@ -6,34 +6,39 @@ import (
 	"time"
 
 	"github.com/cyverse-de/data-usage-api/config"
-	"github.com/jmoiron/sqlx"
+	"github.com/cyverse-de/data-usage-api/util"
 	"github.com/pkg/errors"
 )
 
 type BothDatabases struct {
-	dedb   *DEDatabase
-	icatdb *ICATDatabase
+	deconn        DatabaseTxAccessor
+	icatconn      DatabaseTxAccessor
+	configuration *config.Config
+
+	DERollback func()
+	DECommit   func() error
+
+	ICATRollback func()
+	ICATCommit   func() error
+
+	detx   *DEDatabase
+	icattx *ICATDatabase
 }
 
-func NewBoth(dedb *DEDatabase, icatdb *ICATDatabase) *BothDatabases {
-	return &BothDatabases{dedb: dedb, icatdb: icatdb}
+func NewBoth(dedb DatabaseTxAccessor, icatdb DatabaseTxAccessor, config *config.Config) *BothDatabases {
+	return &BothDatabases{deconn: dedb, icatconn: icatdb, configuration: config}
 }
 
-func NewBothTx(context context.Context, deconn *sqlx.DB, icatconn *sqlx.DB, config *config.Config) (*BothDatabases, func(), func() error, error) {
-	logStats("DE", deconn)
-	detx, err := deconn.BeginTxx(context, nil)
-	if err != nil {
-		return nil, func() {}, func() error { return err }, errors.Wrap(err, "Error creating DE database transaction")
+func (b *BothDatabases) DETx(ctx context.Context) (*DEDatabase, error) {
+	logStats("DE", b.deconn)
+	if b.detx != nil {
+		return b.detx, nil
 	}
 
-	logStats("ICAT", icatconn)
-	icattx, err := icatconn.BeginTxx(context, nil)
+	detx, err := b.deconn.BeginTxx(ctx, nil)
 	if err != nil {
-		return nil, func() {}, func() error { return err }, errors.Wrap(err, "Error creating ICAT transaction")
+		return nil, errors.Wrap(err, "Error creating DE transaction")
 	}
-
-	dedb := NewDE(detx, config)
-	icatdb := NewICAT(icattx, config)
 
 	rb := func() {
 		alreadyDoneErr := "sql: transaction has already been committed or rolled back"
@@ -42,49 +47,115 @@ func NewBothTx(context context.Context, deconn *sqlx.DB, icatconn *sqlx.DB, conf
 			e := errors.Wrap(err, "Error rolling back DE database transaction")
 			log.Error(e)
 		}
-		err = icattx.Rollback()
-		if err != nil && err.Error() != alreadyDoneErr {
-			e := errors.Wrap(err, "Error rolling back ICAT transaction")
-			log.Error(e)
-		}
+		b.detx = nil
+		b.DERollback = func() {}
+		b.DECommit = func() error { return nil }
 	}
 
 	commit := func() error {
 		err := detx.Commit()
+		b.detx = nil
+		b.DERollback = func() {}
+		b.DECommit = func() error { return nil }
 		if err != nil {
 			e := errors.Wrap(err, "Error committing DE database transaction")
 			log.Error(e)
-			icattx.Rollback() // nolint:errcheck
 			return e
-		}
-		err = icattx.Commit()
-		if err != nil {
-			// yes, this swallows the error. We don't write to the ICAT in this service anyway though
-			log.Error(errors.Wrap(err, "Error committing ICAT transaction"))
 		}
 		return nil
 	}
-	return NewBoth(dedb, icatdb), rb, commit, nil
+
+	b.detx = NewDE(detx, b.configuration)
+	b.DERollback = rb
+	b.DECommit = commit
+
+	return b.detx, nil
+}
+
+func (b *BothDatabases) ICATTx(ctx context.Context) (*ICATDatabase, error) {
+	logStats("ICAT", b.icatconn)
+	if b.icattx != nil {
+		return b.icattx, nil
+	}
+
+	icattx, err := b.icatconn.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating DE transaction")
+	}
+
+	rb := func() {
+		alreadyDoneErr := "sql: transaction has already been committed or rolled back"
+		err := icattx.Rollback()
+		if err != nil && err.Error() != alreadyDoneErr {
+			e := errors.Wrap(err, "Error rolling back ICAT transaction")
+			log.Error(e)
+		}
+		b.icattx = nil
+		b.ICATRollback = func() {}
+		b.ICATCommit = func() error { return nil }
+	}
+
+	commit := func() error {
+		err := icattx.Commit()
+		b.icattx = nil
+		b.ICATRollback = func() {}
+		b.ICATCommit = func() error { return nil }
+		if err != nil {
+			e := errors.Wrap(err, "Error committing ICAT transaction")
+			log.Error(e)
+			return e
+		}
+		return nil
+	}
+
+	b.icattx = NewICAT(icattx, b.configuration)
+	b.ICATRollback = rb
+	b.ICATCommit = commit
+
+	return b.icattx, nil
 }
 
 func (b *BothDatabases) UpdateUserDataUsage(context context.Context, username string) (*UserDataUsage, error) {
-	usagenum, err := b.icatdb.UserCurrentDataUsage(context, username)
+	icatdb, err := b.ICATTx(context)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating ICAT transaction")
+	}
+	defer b.ICATRollback()
+
+	usagenum, err := icatdb.UserCurrentDataUsage(context, username)
 	if err == sql.ErrNoRows {
 		usagenum = 0
 		log.Infof("No usage information was found for user %s. Attempting to add a usage of 0 anyway", username)
 	} else if err != nil {
 		return nil, errors.Wrap(err, "Error getting current data usage")
 	}
+	b.ICATRollback()
 
 	// if this update shouldn't be added, or should amend a prior reading, do it here or in the method called below
 	// or maybe have an async cleanup process that deduplicates readings
 
-	res, err := b.dedb.AddUserDataUsage(context, username, usagenum, time.Now())
+	dedb, err := b.DETx(context)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating DE database transaction")
+	}
+	defer b.DERollback()
+
+	res, err := dedb.AddUserDataUsage(context, username, usagenum, time.Now())
 	if err == sql.ErrNoRows {
 		e := errors.Wrap(err, "No data could be inserted. Perhaps the user doesn't exist in the DE database")
 		log.Error(e)
 		return nil, e
+	} else if err != nil {
+		e := errors.Wrap(err, "Error adding user data usage")
+		log.Error(e)
+		return nil, e
+	}
 
+	err = b.DECommit()
+	if err != nil {
+		e := errors.Wrap(err, "Error committing DE transaction")
+		log.Error(e)
+		return nil, e
 	}
 
 	return res, err
@@ -92,28 +163,48 @@ func (b *BothDatabases) UpdateUserDataUsage(context context.Context, username st
 
 func (b *BothDatabases) UpdateUserDataUsageBatch(context context.Context, start, end string) error {
 	// should pass in qualified usernames, icatdb method will strip it as needed
-	usages, err := b.icatdb.BatchCurrentDataUsage(context, start, end)
+	icatdb, err := b.ICATTx(context)
+	if err != nil {
+		return errors.Wrap(err, "Error creating ICAT transaction")
+	}
+	defer b.ICATRollback()
+
+	usages, err := icatdb.BatchCurrentDataUsage(context, start, end)
 	if err != nil {
 		return err
 	}
+	b.ICATRollback()
 
 	log.Tracef("usages in batch: %+v", usages)
 
 	var us []string
 	usagesFixed := make(map[string]int64)
 	for usr, usg := range usages { // keys of usages map
-		us = append(us, b.icatdb.FixUsername(usr))
-		usagesFixed[b.icatdb.FixUsername(usr)] = usg
+		us = append(us, util.FixUsername(usr, b.configuration))
+		usagesFixed[util.FixUsername(usr, b.configuration)] = usg
 	}
 
-	err = b.dedb.EnsureUsers(context, us)
+	dedb, err := b.DETx(context)
+	if err != nil {
+		return errors.Wrap(err, "Error creating DE database transaction")
+	}
+	defer b.DERollback()
+
+	err = dedb.EnsureUsers(context, us)
 	if err != nil {
 		return errors.Wrap(err, "Error ensuring users exist")
 	}
 
-	_, err = b.dedb.AddUserDataUsageBatch(context, usagesFixed, time.Now())
+	_, err = dedb.AddUserDataUsageBatch(context, usagesFixed, time.Now())
 	if err != nil {
 		return errors.Wrap(err, "Error inserting new usage")
+	}
+
+	err = b.DECommit()
+	if err != nil {
+		e := errors.Wrap(err, "Error committing DE transaction")
+		log.Error(e)
+		return e
 	}
 
 	return nil

--- a/db/coordination.go
+++ b/db/coordination.go
@@ -33,7 +33,7 @@ func NewBothTx(context context.Context, deconn *sqlx.DB, deschema string, icatco
 	}
 
 	dedb := NewDE(detx, &config.Config{DBSchema: deschema})
-	icatdb := NewICAT(icattx, userSuffix, zone, rootResourceNames)
+	icatdb := NewICAT(icattx, &config.Config{UserSuffix: userSuffix, Zone: zone, RootResourceNames: rootResourceNames})
 
 	rb := func() {
 		alreadyDoneErr := "sql: transaction has already been committed or rolled back"

--- a/db/coordination.go
+++ b/db/coordination.go
@@ -19,7 +19,7 @@ func NewBoth(dedb *DEDatabase, icatdb *ICATDatabase) *BothDatabases {
 	return &BothDatabases{dedb: dedb, icatdb: icatdb}
 }
 
-func NewBothTx(context context.Context, deconn *sqlx.DB, deschema string, icatconn *sqlx.DB, userSuffix, zone string, rootResourceNames []string) (*BothDatabases, func(), func() error, error) {
+func NewBothTx(context context.Context, deconn *sqlx.DB, icatconn *sqlx.DB, config *config.Config) (*BothDatabases, func(), func() error, error) {
 	logStats("DE", deconn)
 	detx, err := deconn.BeginTxx(context, nil)
 	if err != nil {
@@ -32,8 +32,8 @@ func NewBothTx(context context.Context, deconn *sqlx.DB, deschema string, icatco
 		return nil, func() {}, func() error { return err }, errors.Wrap(err, "Error creating ICAT transaction")
 	}
 
-	dedb := NewDE(detx, &config.Config{DBSchema: deschema})
-	icatdb := NewICAT(icattx, &config.Config{UserSuffix: userSuffix, Zone: zone, RootResourceNames: rootResourceNames})
+	dedb := NewDE(detx, config)
+	icatdb := NewICAT(icattx, config)
 
 	rb := func() {
 		alreadyDoneErr := "sql: transaction has already been committed or rolled back"

--- a/db/coordination.go
+++ b/db/coordination.go
@@ -80,7 +80,7 @@ func (b *BothDatabases) ICATTx(ctx context.Context) (*ICATDatabase, error) {
 
 	icattx, err := b.icatconn.BeginTxx(ctx, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error creating DE transaction")
+		return nil, errors.Wrap(err, "Error creating ICAT transaction")
 	}
 
 	rb := func() {

--- a/db/coordination.go
+++ b/db/coordination.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/cyverse-de/data-usage-api/config"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 )
@@ -31,7 +32,7 @@ func NewBothTx(context context.Context, deconn *sqlx.DB, deschema string, icatco
 		return nil, func() {}, func() error { return err }, errors.Wrap(err, "Error creating ICAT transaction")
 	}
 
-	dedb := NewDE(detx, deschema)
+	dedb := NewDE(detx, &config.Config{DBSchema: deschema})
 	icatdb := NewICAT(icattx, userSuffix, zone, rootResourceNames)
 
 	rb := func() {

--- a/db/db.go
+++ b/db/db.go
@@ -22,6 +22,11 @@ type DatabaseAccessor interface {
 	SelectContext(context.Context, interface{}, string, ...interface{}) error
 }
 
+type DatabaseTxAccessor interface {
+	DatabaseAccessor
+	BeginTxx(context.Context, *sql.TxOptions) (*sqlx.Tx, error)
+}
+
 func logStats(name string, db *sqlx.DB) {
 	stats := db.Stats()
 

--- a/db/db.go
+++ b/db/db.go
@@ -25,9 +25,10 @@ type DatabaseAccessor interface {
 type DatabaseTxAccessor interface {
 	DatabaseAccessor
 	BeginTxx(context.Context, *sql.TxOptions) (*sqlx.Tx, error)
+	Stats() sql.DBStats
 }
 
-func logStats(name string, db *sqlx.DB) {
+func logStats(name string, db DatabaseTxAccessor) {
 	stats := db.Stats()
 
 	log.Infof("%s stats: %d/%d open; %d/%d used/idle", name, stats.OpenConnections, stats.MaxOpenConnections, stats.InUse, stats.Idle)

--- a/db/de.go
+++ b/db/de.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/squirrel"
+	"github.com/cyverse-de/data-usage-api/config"
 	"github.com/pkg/errors"
 )
 
@@ -21,16 +22,16 @@ type UserDataUsage struct {
 }
 
 type DEDatabase struct {
-	db     DatabaseAccessor
-	schema string
+	db            DatabaseAccessor
+	configuration *config.Config
 }
 
-func NewDE(db DatabaseAccessor, schema string) *DEDatabase {
-	return &DEDatabase{db: db, schema: schema}
+func NewDE(db DatabaseAccessor, config *config.Config) *DEDatabase {
+	return &DEDatabase{db: db, configuration: config}
 }
 
 func (d *DEDatabase) Table(name, alias string) string {
-	return fmt.Sprintf("%s.%s AS %s", d.schema, name, alias)
+	return fmt.Sprintf("%s.%s AS %s", d.configuration.DBSchema, name, alias)
 }
 
 func (d *DEDatabase) baseUserUsageSelect() squirrel.SelectBuilder {


### PR DESCRIPTION
First: refactors the database accessors to use the config.Config objects that I'm passing around elsewhere. This makes things easier later.

Then: refactor the coordination code so it opens and closes transactions as needed against each DB, rather than opening two transactions, doing all the work, then closing them both out. This is the main part that should need review. I'll pick out specific stuff that matters in comments.