### PR TITLE
CORE-1802: change the update_operation field in updates sent to QMS

### DIFF
--- a/natsconn/natsconn.go
+++ b/natsconn/natsconn.go
@@ -103,7 +103,7 @@ func NewConnector(cs *ConnectorSettings) (*Connector, error) {
 
 func (nc *Connector) SendUserUsageUpdateMessage(ctx context.Context, res *db.UserDataUsage) error {
 	return gotelnats.Publish(ctx, nc.Conn, "cyverse.qms.user.usages.add",
-		pbinit.NewAddUsage(res.Username, "data.size", "ADD", float64(res.Total)),
+		pbinit.NewAddUsage(res.Username, "data.size", "SET", float64(res.Total)),
 	)
 }
 


### PR DESCRIPTION
This is a tiny change to update the `update_operation` field in data usage update messages that are being sent to QMS.