### PR TITLE
Add zero usages when a user doesn't get returned from the ICAT batch

### DIFF
--- a/db/coordination.go
+++ b/db/coordination.go
@@ -203,7 +203,7 @@ func (b *BothDatabases) UpdateUserDataUsageBatch(context context.Context, start,
 		return nil, errors.Wrap(err, "Error ensuring users exist")
 	}
 
-	res, err := dedb.AddUserDataUsageBatch(ctx, usagesFixed, time.Now())
+	res, err := dedb.AddUserDataUsageBatch(ctx, start, end, usagesFixed, time.Now())
 	if err != nil {
 		return nil, errors.Wrap(err, "Error inserting new usage")
 	}

--- a/db/de.go
+++ b/db/de.go
@@ -94,7 +94,7 @@ func (d *DEDatabase) AddUserDataUsage(context context.Context, username string, 
 	return d.doUserUsage(ctx, query)
 }
 
-func (d *DEDatabase) AddUserDataUsageBatch(context context.Context, usages map[string]int64, time time.Time) ([]*UserDataUsage, error) {
+func (d *DEDatabase) AddUserDataUsageBatch(context context.Context, start, end string, usages map[string]int64, time time.Time) ([]*UserDataUsage, error) {
 	log.Tracef("Inserting usages: %+v at %s", usages, time)
 	ctx, span := otel.Tracer(otelName).Start(context, "AddUserDataUsageBatch")
 	defer span.End()
@@ -105,7 +105,23 @@ func (d *DEDatabase) AddUserDataUsageBatch(context context.Context, usages map[s
 		placeholders = append(placeholders, "(?::text, ?::bigint)")
 		startargs = append(startargs, usr, usg)
 	}
-	startcte := "WITH new_usages (username, usage) AS (VALUES " + strings.Join(placeholders, ",") + ")"
+	nonzero_usages := "new_nonzero_usages (username, usage) AS (VALUES " + strings.Join(placeholders, ",") + ")"
+
+	// Add a 0 for any user whose most recent total is > 0 but who doesn't appear in the batch we got from the ICAT
+	new_usages2, nuargs, err := psql.Select().
+		Column("us.username").
+		Column("?", 0).
+		From(d.Table("user_data_usage", "udu")).
+		Join(fmt.Sprintf("%s ON (us.id = udu.user_id)", d.Table("users", "us"))).
+		LeftJoin("new_nonzero_usages ON users.username = new_nonzero_usages.username").
+		Where(squirrel.Gt{"total": 0}).
+		Where("us.username BETWEEN ? AND ?", start, end).
+		Where("time = (SELECT MAX(time) FROM user_data_usage u2 WHERE u2.user_id = udu.user_id)").
+		ToSql()
+	startargs = append(startargs, nuargs...)
+	new_usages := "new_usages (username, usage) AS (SELECT username, usage from new_nonzero_usages UNION ALL " + new_usages2 + ")"
+
+	startcte := "WITH " + nonzero_usages + ", " + new_usages
 
 	querys, args, err := psql.Insert(d.Table("user_data_usage", "d")).
 		Prefix(startcte, startargs...).

--- a/db/de.go
+++ b/db/de.go
@@ -118,6 +118,11 @@ func (d *DEDatabase) AddUserDataUsageBatch(context context.Context, start, end s
 		Where("us.username BETWEEN ? AND ?", start, end).
 		Where("time = (SELECT MAX(time) FROM user_data_usage u2 WHERE u2.user_id = udu.user_id)").
 		ToSql()
+
+	if err != nil {
+		return nil, errors.Wrap(err, "Error formatting SQL query")
+	}
+
 	startargs = append(startargs, nuargs...)
 	new_usages := "new_usages (username, usage) AS (SELECT username, usage from new_nonzero_usages UNION ALL " + new_usages2 + ")"
 

--- a/db/de.go
+++ b/db/de.go
@@ -108,7 +108,7 @@ func (d *DEDatabase) AddUserDataUsageBatch(context context.Context, start, end s
 	nonzero_usages := "new_nonzero_usages (username, usage) AS (VALUES " + strings.Join(placeholders, ",") + ")"
 
 	// Add a 0 for any user whose most recent total is > 0 but who doesn't appear in the batch we got from the ICAT
-	new_usages2, nuargs, err := psql.Select().
+	new_usages2, nuargs, err := squirrel.Select().
 		Column("us.username").
 		Column("?", 0).
 		From(d.Table("user_data_usage", "udu")).
@@ -117,6 +117,7 @@ func (d *DEDatabase) AddUserDataUsageBatch(context context.Context, start, end s
 		Where(squirrel.Gt{"total": 0}).
 		Where("us.username BETWEEN ? AND ?", start, end).
 		Where("time = (SELECT MAX(time) FROM user_data_usage u2 WHERE u2.user_id = udu.user_id)").
+		Where("new_nonzero_usages.usage IS NULL").
 		ToSql()
 
 	if err != nil {

--- a/db/de.go
+++ b/db/de.go
@@ -113,7 +113,7 @@ func (d *DEDatabase) AddUserDataUsageBatch(context context.Context, start, end s
 		Column("?", 0).
 		From(d.Table("user_data_usage", "udu")).
 		Join(fmt.Sprintf("%s ON (us.id = udu.user_id)", d.Table("users", "us"))).
-		LeftJoin("new_nonzero_usages ON users.username = new_nonzero_usages.username").
+		LeftJoin("new_nonzero_usages ON us.username = new_nonzero_usages.username").
 		Where(squirrel.Gt{"total": 0}).
 		Where("us.username BETWEEN ? AND ?", start, end).
 		Where("time = (SELECT MAX(time) FROM user_data_usage u2 WHERE u2.user_id = udu.user_id)").


### PR DESCRIPTION
(but has a non-zero most recent usage in the DB)

Logic checking is definitely appreciated, little dizzy from all the SQL.