### PR TITLE
Normalize user suffix, remove some unused stuff

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -36,7 +37,7 @@ func NewFromViper(cfg *viper.Viper) (*Config, error) {
 		ICATURI:           cfg.GetString("icat.uri"),
 		Zone:              cfg.GetString("icat.zone"),
 		RootResourceNames: cfg.GetStringSlice("icat.rootResources"),
-		UserSuffix:        cfg.GetString("users.domain"),
+		UserSuffix:        strings.Trim(cfg.GetString("users.domain"), "@"),
 		RefreshInterval:   &ri,
 		AMQPURI:           cfg.GetString("amqp.uri"),
 		AMQPExchangeName:  cfg.GetString("amqp.exchange.name"),

--- a/db/icat.go
+++ b/db/icat.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/cyverse-de/data-usage-api/config"
-	"github.com/cyverse-de/data-usage-api/util"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 )
@@ -20,10 +19,6 @@ type ICATDatabase struct {
 
 func NewICAT(db DatabaseAccessor, config *config.Config) *ICATDatabase {
 	return &ICATDatabase{db: db, configuration: config}
-}
-
-func (i *ICATDatabase) FixUsername(username string) string {
-	return util.FixUsername(username, &config.Config{UserSuffix: i.configuration.UserSuffix})
 }
 
 func (i *ICATDatabase) UnqualifiedUsername(username string) string {

--- a/util/util.go
+++ b/util/util.go
@@ -2,14 +2,13 @@ package util
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/cyverse-de/data-usage-api/config"
 )
 
 func FixUsername(username string, configuration *config.Config) string {
-	if !strings.HasSuffix(username, configuration.UserSuffix) {
-		return fmt.Sprintf("%s@%s", username, configuration.UserSuffix)
-	}
-	return username
+	re, _ := regexp.Compile(`@.*$`)
+	return fmt.Sprintf("%s@%s", re.ReplaceAllString(username, ""), strings.Trim(configuration.UserSuffix, "@"))
 }


### PR DESCRIPTION
Makes sure that the user suffix that comes into the service always has `@` stripped off of it, and changes the FixUsername function to use the regex-type logic I've been implementing in other services for this. `func (i *ICATDatabase) FixUsername` was unused, so I removed it.